### PR TITLE
default year for numeric dates

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ exports = module.exports = function parse(str, usa) {
          parseLastThisNext(str, now) ||
          parseNumberDate(str, usa) ||
          parseNumberDateShortYear(str, usa, 80) ||
+         parseNumberDateNoYear(str, usa, now) ||
          parseWordyDate(str, now) ||
          parseIso8601Date(str);
 };
@@ -26,6 +27,10 @@ var NUMBER_DATE         = /^(3[0-1]|[1-2][0-9]|0?[1-9])[,\|\\\/\-\. ]+(1[0-2]|0?
 var NUMBER_DATE_USA     = /^(1[0-2]|0?[1-9])[,\|\\\/\-\. ]+(3[0-1]|[1-2][0-9]|0?[1-9])[,\|\\\/\-\. ]+([0-9]{4})$/;
 var NUMBER_DATE_SHORT_YEAR         = /^(3[0-1]|[1-2][0-9]|0?[1-9])[,\|\\\/\-\. ]+(1[0-2]|0?[1-9])[,\|\\\/\-\. ]+([0-9]{2})$/;
 var NUMBER_DATE_SHORT_YEAR_USA     = /^(1[0-2]|0?[1-9])[,\|\\\/\-\. ]+(3[0-1]|[1-2][0-9]|0?[1-9])[,\|\\\/\-\. ]+([0-9]{2})$/;
+var NUMBER_DATE_NO_YEAR   = /^(3[0-1]|[1-2][0-9]|0?[1-9])[,\|\\\/\-\. ]+(1[0-2]|0?[1-9])$/;
+var NUMBER_DATE_NO_YEAR_USA     = /^(1[0-2]|0?[1-9])[,\|\\\/\-\. ]+(3[0-1]|[1-2][0-9]|0?[1-9])$/;
+
+
 var ISO_8601_DATE       = /^([0-9]{4})-?(1[0-2]|0?[1-9])-?(3[0-1]|[1-2][0-9]|0?[1-9])$/;
 
 function addDays(now, numberOfDays) {
@@ -82,6 +87,17 @@ function parseNumberDateShortYear(str, usa, cutoff) {
     var year = (+match[3]);
     if (year > cutoff) year += 1900;
     else year += 2000;
+    return usa ? date(year, match[1] - 1, +match[2]) : date(year, match[2] - 1, +match[1]);
+  } else {
+    return null;
+  }
+}
+
+exports.parseNumberDateNoYear = parseNumberDateNoYear;
+function parseNumberDateNoYear(str, usa, today) {
+  var match = usa ? NUMBER_DATE_NO_YEAR_USA.exec(str) : NUMBER_DATE_NO_YEAR.exec(str);
+  if (match) {
+    var year = today.getFullYear();
     return usa ? date(year, match[1] - 1, +match[2]) : date(year, match[2] - 1, +match[1]);
   } else {
     return null;

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,20 @@ describe('parseNumberDateShortYear', function (input) {
   equal('02-02-85', '1985-02-02');
   equal('80-80-12', null);
 });
+
+describe('parseNumberNoYear', function (input) {
+  return dehumanize.parseNumberNoYear(input, false, new Date(2012, 1, 1)));
+}, function (equal) {
+  equal('2-22', '2012-02-02');
+  equal('2/8', '2012-08-02');
+  equal('2\\8', '2012-08-02');
+  equal('2,4', '2012-04-02');
+  equal('2 4', '2012-04-02');
+  equal('02-02', '2012-02-02');
+  equal('30/01', '2012-01-30');
+  equal('80-80', null);
+});
+
 describe('monthFromName', function (input) {
   return dehumanize.monthFromName(input);
 }, function (equal) {
@@ -68,6 +82,7 @@ describe('monthFromName', function (input) {
   equal('foo', null);
   equal('foobar', null);
 });
+
 describe('parseWordyDate', function (input) {
   return dehumanize.parseWordyDate(input, new Date(2012, 1, 1));
 }, function (equal) {
@@ -78,7 +93,6 @@ describe('parseWordyDate', function (input) {
   equal('12th june 2012', '2012-06-12');
   equal('12 june 2012', '2012-06-12');
   equal('12th june', '2012-06-12');
-
   equal('12th ju', null);
   equal('12th ju 2012', null);
   equal('36th june', null);

--- a/test/index.js
+++ b/test/index.js
@@ -60,7 +60,7 @@ describe('parseNumberDateShortYear', function (input) {
 });
 
 describe('parseNumberNoYear', function (input) {
-  return dehumanize.parseNumberNoYear(input, false, new Date(2012, 1, 1)));
+  return dehumanize.parseNumberNoYear(input, false, new Date(2012, 1, 1));
 }, function (equal) {
   equal('2-22', '2012-02-02');
   equal('2/8', '2012-08-02');

--- a/test/index.js
+++ b/test/index.js
@@ -59,8 +59,8 @@ describe('parseNumberDateShortYear', function (input) {
   equal('80-80-12', null);
 });
 
-describe('parseNumberNoYear', function (input) {
-  return dehumanize.parseNumberNoYear(input, false, new Date(2012, 1, 1));
+describe('parseNumberDateNoYear', function (input) {
+  return dehumanize.parseNumberDateNoYear(input, false, new Date(2012, 1, 1));
 }, function (equal) {
   equal('2-22', '2012-02-02');
   equal('2/8', '2012-08-02');

--- a/test/index.js
+++ b/test/index.js
@@ -62,7 +62,7 @@ describe('parseNumberDateShortYear', function (input) {
 describe('parseNumberDateNoYear', function (input) {
   return dehumanize.parseNumberDateNoYear(input, false, new Date(2012, 1, 1));
 }, function (equal) {
-  equal('2-22', '2012-02-02');
+  equal('2-2', '2012-02-02');
   equal('2/8', '2012-08-02');
   equal('2\\8', '2012-08-02');
   equal('2,4', '2012-04-02');


### PR DESCRIPTION
To allow entry of dates without a year by defaulting to the current year
