### PR TITLE
Allow for any prefix of month. Closes #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,16 +172,12 @@ function parseIso8601Date(string) {
 
 exports.monthFromName = monthFromName;
 function monthFromName(month) {
-  var monthIndex;
-  var monthCount = 0;
   var monthAbreviations = MONTH_NAMES.map(function (name) { return name.substr(0, month.length); });
-  var monthPosition = monthAbreviations.indexOf(month);
-  while ( monthPosition !== -1 && monthCount <= 2 ) { // If more than one found, stop looking.
-    monthCount++;
-    monthPosition = monthAbreviations.indexOf(month, monthPosition + 1);
-    monthIndex = monthCount === 1 ? monthAbreviations.indexOf(month) : MONTH_NAMES.indexOf(month);
+  var monthIndex = monthAbreviations.indexOf(month);
+  if (monthIndex !== -1 && monthAbreviations.indexOf(month, monthIndex + 1) === -1) {
+    return monthIndex;
   }
-  return monthCount === 1 ? monthIndex : null;
+  return null;
 }
 
 exports.date = date;

--- a/index.js
+++ b/index.js
@@ -170,11 +170,18 @@ function parseIso8601Date(string) {
   }
 }
 
-var monthAbreviations = MONTH_NAMES.map(function (name) { return name.substr(0, 3); });
 exports.monthFromName = monthFromName;
 function monthFromName(month) {
-  var monthIndex = month.length === 3 ? monthAbreviations.indexOf(month) : MONTH_NAMES.indexOf(month);
-  return monthIndex >= 0 ? monthIndex : null;
+  var monthIndex;
+  var monthCount = 0;
+  var monthAbreviations = MONTH_NAMES.map(function (name) { return name.substr(0, month.length); });
+  var monthPosition = monthAbreviations.indexOf(month);
+  while ( monthPosition !== -1 && monthCount <= 2 ) { // If more than one found, stop looking.
+    monthCount++;
+    monthPosition = monthAbreviations.indexOf(month, monthPosition + 1);
+    monthIndex = monthCount === 1 ? monthAbreviations.indexOf(month) : MONTH_NAMES.indexOf(month);
+  }
+  return monthCount === 1 ? monthIndex : null;
 }
 
 exports.date = date;

--- a/test/index.js
+++ b/test/index.js
@@ -75,10 +75,18 @@ describe('parseNumberDateNoYear', function (input) {
 describe('monthFromName', function (input) {
   return dehumanize.monthFromName(input);
 }, function (equal) {
+  equal('january', 0);
+  equal('januar', 0);
+  equal('janua', 0);
+  equal('janu', 0);
+  equal('jan', 0);
+  equal('ja', 0);
   equal('june', 5);
   equal('jun', 5);
-  equal('january', 0);
-  equal('jan', 0);
+  equal('july', 6);
+  equal('jul', 6);
+  equal('ju', null);
+  equal('j', null);
   equal('foo', null);
   equal('foobar', null);
 });


### PR DESCRIPTION
Code added to: `monthFromName`
- Moved `monthAbbreviations` within function.
- This creates the map based on the length of the `month` provided.
- while statement goes through the monthAbbreviations for a second match
  - if so, return null; if not, return index

Note: This does not use a _trie_, depending on need that can replace the
need.

Tests added to: `monthFromName`
- Iterate over `january`, `june`, and `july` and their _correct_
  spellings at every step of the way.
  - PASS: `jun`, `jul`, `ja`, `jan`, `janu`, etc.
  - FAIL: `ju` (returns null since there is more than one match)
  - FAIL: `j` (returns null since there is more than one match)
