### PR TITLE
Allow for short weekday names (mon, tue, etc) #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,16 +78,19 @@ function parseNearbyDays(string, now) {
 exports.parseLastThisNext = parseLastThisNext;
 function parseLastThisNext(string, now) {
   var tokens = string.split(/[,\s]+/);
-
   if (['last', 'this', 'next'].indexOf(tokens[0]) >= 0 &&
-      DAY_NAMES.indexOf(tokens[1]) >= 0 &&
-      tokens.length === 2) {
-    var dayDiff = DAY_NAMES.indexOf(tokens[1]) - now.getDay();
-    if (dayDiff < 0) dayDiff += 7;
-
-    if (tokens[0] === 'last') return addDays(now, dayDiff - 7);
-    if (tokens[0] === 'this') return addDays(now, dayDiff);
-    if (tokens[0] === 'next') return addDays(now, dayDiff + 7);
+      tokens.length === 2 ) {
+    var dayAbbreviations = DAY_NAMES.map(function (name) { return name.substr(0, tokens[1].length); });
+    var dayIndex = dayAbbreviations.indexOf(tokens[1]);
+    if (dayIndex !== -1 &&
+        dayAbbreviations.indexOf(tokens[1], dayIndex + 1) === -1) {
+      var dayDiff = dayIndex - now.getDay();
+      if (dayDiff < 0) dayDiff += 7;
+      if (tokens[0] === 'last') return addDays(now, dayDiff - 7);
+      if (tokens[0] === 'this') return addDays(now, dayDiff);
+      if (tokens[0] === 'next') return addDays(now, dayDiff + 7);
+    }
+    return null;
   } else {
     return null;
   }
@@ -172,9 +175,10 @@ function parseIso8601Date(string) {
 
 exports.monthFromName = monthFromName;
 function monthFromName(month) {
-  var monthAbreviations = MONTH_NAMES.map(function (name) { return name.substr(0, month.length); });
-  var monthIndex = monthAbreviations.indexOf(month);
-  if (monthIndex !== -1 && monthAbreviations.indexOf(month, monthIndex + 1) === -1) {
+  var monthAbbreviations = MONTH_NAMES.map(function (name) { return name.substr(0, month.length); });
+  var monthIndex = monthAbbreviations.indexOf(month);
+  if (monthIndex !== -1 &&
+      monthAbbreviations.indexOf(month, monthIndex + 1) === -1) {
     return monthIndex;
   }
   return null;

--- a/test/index.js
+++ b/test/index.js
@@ -28,8 +28,13 @@ describe('parseLastThisNext', function (input) {
   return dehumanize.parseLastThisNext(input, new Date(2000, 0, 5));
 }, function (equal) {
   equal('next monday', '2000-01-17');
+  equal('next m', '2000-01-17');
   equal('last tuesday', '2000-01-04');
+  equal('last tu', '2000-01-04');
   equal('this thursday', '2000-01-06');
+  equal('this th', '2000-01-06');
+  equal('last t', null);
+  equal('next s', null);
   equal('foo bar', null);
 });
 


### PR DESCRIPTION
This will allow for _almost_ any character length of a properly spelled
day of the week.

**PASS**: monday, monda, mond, mon, mo, m
**PASS**: su, tu, th, sa, sun, tue, etc.
**FAIL**: t, s (returns null if more than one match found)

5 tests added.

(+) Spelling correction: `monthAbbreviations`
