### PR TITLE
Short weekday names #9 POC for days ago/from now #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,12 +99,18 @@ function parseLastThisNext(string, now) {
 exports.parseAgoFrom = parseAgoFrom;
 function parseAgoFrom(string, now) {
   var tokens = string.split(/[,\s]+/);
-  if (['day', 'days'].indexOf(tokens[1]) >= 0 &&
+  if (['day', 'days', 'week', 'weeks'].indexOf(tokens[1]) >= 0 &&
       tokens[0].match(NUMBER) &&
       ['ago', 'from'].indexOf(tokens[2]) >= 0
     ) {
-      if (tokens[2] === 'ago') return addDays(now, tokens[0] * -1);
-      if (tokens[2] === 'from') return addDays(now, tokens[0]);
+      if (tokens[2] === 'ago') {
+        if (['day', 'days'].indexOf(tokens[1]) >= 0) return addDays(now, tokens[0] * -1);
+        if (['week', 'weeks'].indexOf(tokens[1]) >= 0) return addDays(now, (tokens[0] * 7) * -1);
+      }
+      if (tokens[2] === 'from') {
+        if (['day', 'days'].indexOf(tokens[1]) >= 0) return addDays(now, tokens[0]);
+        if (['week', 'weeks'].indexOf(tokens[1]) >= 0) return addDays(now, (tokens[0] * 7));
+      }
       return null;
     } else {
     return null;

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ exports = module.exports = function parse(str, options) {
 
   return parseNearbyDays(str, options.now) ||
          parseLastThisNext(str, options.now) ||
+         parseAgoFrom(str, options.now) ||
          parseNumberDate(str, options.usa) ||
          parseNumberDateShortYear(str, options.usa, options.cutoff) ||
          parseNumberDateNoYear(str, options.usa, options.now) ||
@@ -61,7 +62,6 @@ function addDays(now, numberOfDays) {
   return date(result.getFullYear(), result.getMonth(), result.getDate());
 }
 
-
 exports.parseNearbyDays = parseNearbyDays;
 function parseNearbyDays(string, now) {
   if (string == 'today') {
@@ -78,17 +78,35 @@ function parseNearbyDays(string, now) {
 exports.parseLastThisNext = parseLastThisNext;
 function parseLastThisNext(string, now) {
   var tokens = string.split(/[,\s]+/);
-
   if (['last', 'this', 'next'].indexOf(tokens[0]) >= 0 &&
-      DAY_NAMES.indexOf(tokens[1]) >= 0 &&
-      tokens.length === 2) {
-    var dayDiff = DAY_NAMES.indexOf(tokens[1]) - now.getDay();
-    if (dayDiff < 0) dayDiff += 7;
-
-    if (tokens[0] === 'last') return addDays(now, dayDiff - 7);
-    if (tokens[0] === 'this') return addDays(now, dayDiff);
-    if (tokens[0] === 'next') return addDays(now, dayDiff + 7);
+      tokens.length === 2 ) {
+    var dayAbbreviations = DAY_NAMES.map(function (name) { return name.substr(0, tokens[1].length); });
+    var dayIndex = dayAbbreviations.indexOf(tokens[1]);
+    if (dayIndex !== -1 &&
+        dayAbbreviations.indexOf(tokens[1], dayIndex + 1) === -1) {
+      var dayDiff = dayIndex - now.getDay();
+      if (dayDiff < 0) dayDiff += 7;
+      if (tokens[0] === 'last') return addDays(now, dayDiff - 7);
+      if (tokens[0] === 'this') return addDays(now, dayDiff);
+      if (tokens[0] === 'next') return addDays(now, dayDiff + 7);
+    }
+    return null;
   } else {
+    return null;
+  }
+}
+
+exports.parseAgoFrom = parseAgoFrom;
+function parseAgoFrom(string, now) {
+  var tokens = string.split(/[,\s]+/);
+  if (['day', 'days'].indexOf(tokens[1]) >= 0 &&
+      tokens[0].match(NUMBER) &&
+      ['ago', 'from'].indexOf(tokens[2]) >= 0
+    ) {
+      if (tokens[2] === 'ago') return addDays(now, tokens[0] * -1);
+      if (tokens[2] === 'from') return addDays(now, tokens[0]);
+      return null;
+    } else {
     return null;
   }
 }
@@ -172,9 +190,10 @@ function parseIso8601Date(string) {
 
 exports.monthFromName = monthFromName;
 function monthFromName(month) {
-  var monthAbreviations = MONTH_NAMES.map(function (name) { return name.substr(0, month.length); });
-  var monthIndex = monthAbreviations.indexOf(month);
-  if (monthIndex !== -1 && monthAbreviations.indexOf(month, monthIndex + 1) === -1) {
+  var monthAbbreviations = MONTH_NAMES.map(function (name) { return name.substr(0, month.length); });
+  var monthIndex = monthAbbreviations.indexOf(month);
+  if (monthIndex !== -1 &&
+      monthAbbreviations.indexOf(month, monthIndex + 1) === -1) {
     return monthIndex;
   }
   return null;

--- a/test/index.js
+++ b/test/index.js
@@ -28,9 +28,24 @@ describe('parseLastThisNext', function (input) {
   return dehumanize.parseLastThisNext(input, new Date(2000, 0, 5));
 }, function (equal) {
   equal('next monday', '2000-01-17');
+  equal('next m', '2000-01-17');
   equal('last tuesday', '2000-01-04');
+  equal('last tu', '2000-01-04');
   equal('this thursday', '2000-01-06');
+  equal('this th', '2000-01-06');
+  equal('last t', null);
+  equal('next s', null);
   equal('foo bar', null);
+});
+
+describe('parseAgoFrom', function (input) {
+  return dehumanize.parseAgoFrom(input, new Date(2000, 0, 5));
+}, function (equal) {
+  equal('2 days ago', '2000-01-03');
+  equal('2 days from now', '2000-01-07');
+  equal('1 day ago', '2000-01-04');
+  equal('1 day from now', '2000-01-06');
+  equal('foo days ago', null);
 });
 
 describe('parseNumberDate', function (input) {

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,10 @@ describe('parseAgoFrom', function (input) {
   equal('2 days from now', '2000-01-07');
   equal('1 day ago', '2000-01-04');
   equal('1 day from now', '2000-01-06');
+  equal('1 week from now', '2000-01-12');
+  equal('2 weeks from now', '2000-01-19');
+  equal('1 week ago', '1999-12-29');
+  equal('2 weeks ago', '1999-12-22');
   equal('foo days ago', null);
 });
 


### PR DESCRIPTION
Allow for short weekday names, as long as they do not conflict with
another.
**PASS:** monday, monda, mond, mon, mo, m
**PASS:** sat, sa, sun, sa, tue, tu, thu, th
**FAIL:** s, t

For now only support for DAYS has been introduced for "ago" and "from
now"

**PASS:** # day/s ago, # day/s from now
**FAIL:** # month/s ago, # year/s ago, # month/s from now, # year/s from now

Months/ Years can be added in a dot / later version.
